### PR TITLE
Compile `std` library without `restricted_std` feature

### DIFF
--- a/library/std/build.rs
+++ b/library/std/build.rs
@@ -31,13 +31,10 @@ fn main() {
         || target.contains("espidf")
         || target.contains("solid")
         || target.contains("nintendo-3ds")
+        || target.contains("assigner")
     {
         // These platforms don't have any special requirements.
-    } else if target.contains("assigner") {
-        // We require assigner target to have restricted std.
-        println!("cargo:rustc-cfg=feature=\"restricted-std\"");
-    }
-     else {
+    } else {
         // This is for Cargo's build-std support, to mark std as unstable for
         // typically no_std platforms.
         // This covers:

--- a/library/std/src/sys_common/mod.rs
+++ b/library/std/src/sys_common/mod.rs
@@ -42,10 +42,27 @@ cfg_if::cfg_if! {
     }
 }
 
+#[cfg(bootstrap)]
 cfg_if::cfg_if! {
     if #[cfg(any(target_os = "l4re",
                  target_os = "hermit",
                  feature = "restricted-std",
+                 all(target_family = "wasm", not(target_os = "emscripten")),
+                 all(target_vendor = "fortanix", target_env = "sgx")))] {
+        pub use crate::sys::net;
+    } else {
+        pub mod net;
+    }
+}
+
+// Because stage0 compiler used at the bootstrap doent't know anything about "assigner",
+// we have to separate this gates.
+#[cfg(not(bootstrap))]
+cfg_if::cfg_if! {
+    if #[cfg(any(target_os = "l4re",
+                 target_os = "hermit",
+                 feature = "restricted-std",
+                 target_arch = "assigner",
                  all(target_family = "wasm", not(target_os = "emscripten")),
                  all(target_vendor = "fortanix", target_env = "sgx")))] {
         pub use crate::sys::net;

--- a/library/test/src/lib.rs
+++ b/library/test/src/lib.rs
@@ -22,10 +22,6 @@
 #![feature(process_exitcode_internals)]
 #![feature(panic_can_unwind)]
 #![feature(test)]
-// FIXME: (aleasims) this feature should be set only for "assigner" arch.
-// But now I don't see any ways to achive this since stage0 compiler is not aware
-// of "assigner" arch and this results into compilation error of std at stage0.
-#![cfg_attr(not(bootstrap), feature(restricted_std))]
 
 // Public reexports
 pub use self::bench::{black_box, Bencher};


### PR DESCRIPTION
Closes #3 