### PR TITLE
Add fields and curves to optimized univariant struct layouts

### DIFF
--- a/compiler/rustc_abi/src/layout.rs
+++ b/compiler/rustc_abi/src/layout.rs
@@ -224,6 +224,12 @@ pub trait LayoutCalculator {
                             Abi::ScalarPair(..) => {
                                 abi = field.abi;
                             }
+                            // Plain fields and curves are unpacked always.
+                            // We don't care about C ABI.
+                            // See issue: https://github.com/NilFoundation/zkllvm-rslang/issues/67
+                            Abi::Field(_) | Abi::Curve(_) => {
+                                abi = field.abi;
+                            }
                             _ => {}
                         }
                     }

--- a/compiler/rustc_const_eval/src/interpret/projection.rs
+++ b/compiler/rustc_const_eval/src/interpret/projection.rs
@@ -109,6 +109,8 @@ where
                 assert!(match (base.layout.abi, field_layout.abi) {
                     (Abi::Scalar(..), Abi::Scalar(..)) => true,
                     (Abi::ScalarPair(..), Abi::ScalarPair(..)) => true,
+                    (Abi::Field(..), Abi::Field(..)) => true,
+                    (Abi::Curve(..), Abi::Curve(..)) => true,
                     _ => false,
                 });
                 assert!(offset.bytes() == 0);


### PR DESCRIPTION
Now for code:

```rust
struct S(__zkllvm_field_pallas_base);
fn test() -> S { S(0g) }
```

compiler will produce optimized LLVM IR:

```llvm
define __zkllvm_field_pallas_base @test() {
start:
  ret __zkllvm_field_pallas_base f0x0
}
```